### PR TITLE
Updates to dev-env to run on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,10 @@ fmtcheck:
 fmt:
 	gofmt -w $(GOFMT_FILES)
 
-dev-env: dev
+# builds for linux/amd64, then spins up a few containers for testing
+dev-env:
+	@CGO_ENABLED=0 BUILD_TAGS='$(BUILD_TAGS)' VAULT_DEVENV_BUILD=1 sh -c "'$(CURDIR)/scripts/build.sh'"
+	GOOS=linux GOARCH=amd64 go build -o bin/login-kerb ./cmd/login-kerb
 	./scripts/dev_env.sh
 
 integration: dev

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,6 +45,15 @@ if [ "${VAULT_DEV_BUILD}x" != "x" ]; then
     XC_OSARCH=$(go env GOOS)/$(go env GOARCH)
 fi
 
+# If its devenv we only build for linux/amd64 - as this ends up in the containers
+if [ "${VAULT_DEVENV_BUILD}x" != "x" ]; then
+  XC_OS="linux"
+  XC_ARCH="amd64"
+  XC_OSARCH="linux/amd64"
+  # We set this to 1 now so that we don't zip and copy to the dist folder later
+  VAULT_DEV_BUILD=1
+fi
+
 # Build!
 echo "==> Building..."
 gox \
@@ -60,11 +69,14 @@ IFS=: MAIN_GOPATH=($GOPATH)
 IFS=$OLDIFS
 
 # Copy our OS/Arch to the bin/ directory
-DEV_PLATFORM="./pkg/$(go env GOOS)_$(go env GOARCH)"
-for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
-    cp ${F} bin/
-    cp ${F} ${MAIN_GOPATH}/bin/
-done
+# Unless we're in DEVENV mode
+if [ "${VAULT_DEVENV_BUILD}x" = "x" ]; then
+  DEV_PLATFORM="./pkg/$(go env GOOS)_$(go env GOARCH)"
+  for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
+      cp ${F} bin/
+      cp ${F} ${MAIN_GOPATH}/bin/
+  done
+fi
 
 if [ "${VAULT_DEV_BUILD}x" = "x" ]; then
     # Zip and copy to the dist dir

--- a/scripts/dev_env.sh
+++ b/scripts/dev_env.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  base64cmd="base64 -D"
+  sleepcmd="while true; do sleep 86400; done"
+else
+  base64cmd="base64 -d"
+  sleepcmd="sleep infinity"
+fi
+
 VAULT_VER=$(curl https://api.github.com/repos/hashicorp/vault/tags?page=1 | python -c "import sys, json; print(json.load(sys.stdin)[0]['name'][1:])")
 VAULT_PORT=8200
 SAMBA_VER=4.8.12
+
+VAULT_TOKEN=root
 
 DOMAIN_ADMIN_PASS=Pa55word!
 DOMAIN_VAULT_ACCOUNT=vault_svc
@@ -31,6 +41,7 @@ function stop_infrastructure() {
   stop_domain
   delete_network
   echo 'Dev environment stopped'
+  exit 0
 }
 
 function create_network() {
@@ -148,7 +159,8 @@ function prepare_files() {
   mkdir -p ${TESTS_DIR}/integration
   pushd ${TESTS_DIR}/integration
   write_kerb_config
-  base64 -d $WD/grace.keytab.base64 > $TESTS_DIR/integration/grace.keytab
+  # base64 -d $WD/grace.keytab.base64 > $TESTS_DIR/integration/grace.keytab
+  eval "$base64cmd" $WD/grace.keytab.base64 > $TESTS_DIR/integration/grace.keytab
 }
 
 function remove_files() {
@@ -166,7 +178,7 @@ function stop_domain_joined_container() {
 function test_joined_container() {
   docker exec $DOMAIN_JOINED_CONTAINER \
     pip install --quiet requests-kerberos
-  docker cp bin/login-kerb $DOMAIN_JOINED_CONTAINER:/usr/local/bin/login-kerb
+  docker cp $WD/bin/login-kerb $DOMAIN_JOINED_CONTAINER:/usr/local/bin/login-kerb
 }
 
 function prepare_outer_environment() {
@@ -181,7 +193,7 @@ function output_dev_vars() {
   echo ''
   echo 'Copy and paste the following variables into your working shell:'
   echo ''
-  echo "export VAULT_TOKEN=root"
+  echo "export VAULT_TOKEN=${VAULT_TOKEN}"
   echo "export VAULT_ADDR=http://localhost:8200"
   echo "export DOMAIN_DN=${DOMAIN_DN}"
   echo "export DOMAIN_JOINED_CONTAINER=${DOMAIN_JOINED_CONTAINER}"
@@ -214,7 +226,8 @@ function main() {
 
   # Now we'll hang until the user hits CTRL+C to tear everything down.
   echo 'To stop and cleanup, press CTRL+C'
-  sleep infinity
+  # sleep infinity
+  eval "$sleepcmd"
   return 0
 }
 main


### PR DESCRIPTION
Hey @tyrannosaurus-becks,

Just some minor adjustments that helped me get this up and going on macOS, I don't believe this will break anything on linux.

Some slight adjustments to the `dev-env` make target so it works on macOS. 
- Force the build to linux/amd64
- Don't copy built packages into the bin folders (as they're just used in the containers)
- Slight tweaks because macOS bash is different
- dev_env.sh now sets the `VAULT_TOKEN` to `root`