### PR TITLE
Prevent panics from readBytes in gokrb5 keytab/keytab.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/sirupsen/logrus v1.4.2 // indirect
-	github.com/tyrannosaurus-becks/gokrb5 v0.0.0-20191111224307-01cf50c9a364
+	github.com/tyrannosaurus-becks/gokrb5 v0.0.0-20191120183833-5a54eb5fa77c
 	gopkg.in/jcmturner/goidentity.v3 v3.0.0
 	gopkg.in/ldap.v3 v3.0.3
 	gotest.tools v2.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tyrannosaurus-becks/gokrb5 v0.0.0-20191111224307-01cf50c9a364 h1:bNdVv3JJRONZ8BWnaNEovINj89T2rl7Gq7NiQlVnAJU=
 github.com/tyrannosaurus-becks/gokrb5 v0.0.0-20191111224307-01cf50c9a364/go.mod h1:L/yrz48GUgsVj/Q+vGgSE0+U8PGSuqj2eEMjaESszAw=
+github.com/tyrannosaurus-becks/gokrb5 v0.0.0-20191120183833-5a54eb5fa77c h1:ifJ/HypUU29Tbvl+JQffHQQV4Ayvuv+3Z1ZuBuwsL08=
+github.com/tyrannosaurus-becks/gokrb5 v0.0.0-20191120183833-5a54eb5fa77c/go.mod h1:L/yrz48GUgsVj/Q+vGgSE0+U8PGSuqj2eEMjaESszAw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191106202628-ed6320f186d4 h1:PDpCLFAH/YIX0QpHPf2eO7L4rC2OOirBrKtXTLLiNTY=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -151,7 +151,7 @@ github.com/pkg/errors
 github.com/ryanuber/go-glob
 # github.com/sirupsen/logrus v1.4.2
 github.com/sirupsen/logrus
-# github.com/tyrannosaurus-becks/gokrb5 v0.0.0-20191111224307-01cf50c9a364
+# github.com/tyrannosaurus-becks/gokrb5 v0.0.0-20191120183833-5a54eb5fa77c
 github.com/tyrannosaurus-becks/gokrb5/client
 github.com/tyrannosaurus-becks/gokrb5/config
 github.com/tyrannosaurus-becks/gokrb5/keytab


### PR DESCRIPTION
This PR pulls my fork's fix for https://github.com/jcmturner/gokrb5/issues/339. Identical PR lives at https://github.com/jcmturner/gokrb5/pull/340 and we'll want to watch for if/when that's merged into master.