### PR TITLE
length check when parsing krb5tokens

### DIFF
--- a/internal/gokrb5/spnego/krb5Token.go
+++ b/internal/gokrb5/spnego/krb5Token.go
@@ -71,6 +71,9 @@ func (m *KRB5Token) Unmarshal(b []byte) error {
 		return fmt.Errorf("error unmarshalling KRB5Token OID: %v", err)
 	}
 	m.OID = oid
+	if len(r) < 3 {
+		return fmt.Errorf("krb5token too short")
+	}
 	m.tokID = r[0:2]
 	switch hex.EncodeToString(m.tokID) {
 	case TOK_ID_KRB_AP_REQ:

--- a/internal/gokrb5/spnego/krb5Token.go
+++ b/internal/gokrb5/spnego/krb5Token.go
@@ -71,7 +71,7 @@ func (m *KRB5Token) Unmarshal(b []byte) error {
 		return fmt.Errorf("error unmarshalling KRB5Token OID: %v", err)
 	}
 	m.OID = oid
-	if len(r) < 3 {
+	if len(r) < 2 {
 		return fmt.Errorf("krb5token too short")
 	}
 	m.tokID = r[0:2]


### PR DESCRIPTION
Fuzzed some crashes in https://github.com/hashicorp/vault-plugin-auth-kerberos/blob/d95638b55787579a88380bea14a153c56340e49f/internal/gokrb5/spnego/krb5Token.go#L67