### PR TITLE
At login, verify that the realm matches between Kerberos and LDAP

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -116,15 +116,15 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		raw := r.Context().Value(spnego.CTXKeyCredentials)
 		if raw == nil {
-			_, _ = w.Write([]byte("identity credentials are not included"))
 			w.WriteHeader(400)
+			_, _ = w.Write([]byte("identity credentials are not included"))
 			return
 		}
 		ok := false
 		identity, ok = raw.(goidentity.Identity)
 		if !ok {
-			_, _ = w.Write([]byte(fmt.Sprintf("identity credentials are malformed: %+v", raw)))
 			w.WriteHeader(400)
+			_, _ = w.Write([]byte(fmt.Sprintf("identity credentials are malformed: %+v", raw)))
 			return
 		}
 		b.Logger().Debug(fmt.Sprintf("identity: %+v", identity))
@@ -137,8 +137,8 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 		// passing Kerberos authentication, and then extracting group membership, and
 		// therefore policies, from a separate directory.
 		if identity.Domain() != ldapCfg.ConfigEntry.UPNDomain {
-			_, _ = w.Write([]byte(fmt.Sprintf("identity domain of %q doesn't match LDAP upndomain of %q", identity.Domain(), ldapCfg.ConfigEntry.UPNDomain)))
 			w.WriteHeader(400)
+			_, _ = w.Write([]byte(fmt.Sprintf("identity domain of %q doesn't match LDAP upndomain of %q", identity.Domain(), ldapCfg.ConfigEntry.UPNDomain)))
 			return
 		}
 		authenticated = true

--- a/path_login.go
+++ b/path_login.go
@@ -116,18 +116,31 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		raw := r.Context().Value(spnego.CTXKeyCredentials)
 		if raw == nil {
-			b.Logger().Debug("identity is nil")
-			w.Write([]byte("identity credentials are not included"))
+			_, _ = w.Write([]byte("identity credentials are not included"))
+			w.WriteHeader(400)
 			return
 		}
 		ok := false
 		identity, ok = raw.(goidentity.Identity)
 		if !ok {
-			b.Logger().Debug(fmt.Sprintf("identity credentials are malformed: %+v", raw))
-			w.Write([]byte(fmt.Sprintf("identity credentials are malformed: %+v", raw)))
+			_, _ = w.Write([]byte(fmt.Sprintf("identity credentials are malformed: %+v", raw)))
+			w.WriteHeader(400)
 			return
 		}
 		b.Logger().Debug(fmt.Sprintf("identity: %+v", identity))
+
+		// Verify that the realm on the LDAP config is the same as the identity's
+		// realm. The UPNDomain denotes the realm on the LDAP config, and the identity
+		// domain likewise identifies the realm. This is a case sensitive check.
+		// This covers an edge case where, potentially, there has been drift between the LDAP
+		// config's realm and the Kerberos realm. In such a case, it prevents a user from
+		// passing Kerberos authentication, and then extracting group membership, and
+		// therefore policies, from a separate directory.
+		if identity.Domain() != ldapCfg.ConfigEntry.UPNDomain {
+			_, _ = w.Write([]byte(fmt.Sprintf("identity domain of %q doesn't match LDAP upndomain of %q", identity.Domain(), ldapCfg.ConfigEntry.UPNDomain)))
+			w.WriteHeader(400)
+			return
+		}
 		authenticated = true
 	})
 

--- a/scripts/dev_env.sh
+++ b/scripts/dev_env.sh
@@ -34,7 +34,7 @@ function start_infrastructure() {
 }
 
 function stop_infrastructure() {
-  echo 'Stopping Docker container and removing network, please wait...'
+  echo 'Stopping Docker containers and removing network, please wait...'
   stop_domain_joined_container
   stop_vault
   stop_domain


### PR DESCRIPTION
This PR adds a check that the realm of the identity logging into Kerberos _is also_ the same realm that LDAP is using. 

No tests are added because the code's integration tests already move through this section of code. Because they continue to pass, this shows that the additional check doesn't negatively effect one's ability to use the plugin end-to-end when using it in an expected way.