### PR TITLE
Add client config option disabling FAST negotiation

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -131,7 +131,7 @@ type LoginCfg struct {
 	// a mechanism for tunneling pre-authentication exchanges using armoured
 	// KDC messages. FAST provides increased resistance to passive password
 	// guessing attacks.
-	// Active Directory does not commonly support FAST negotiation.
+	// Some common Kerberos implementations do not support FAST negotiation.
 	DisableFASTNegotiation bool
 }
 

--- a/cli.go
+++ b/cli.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/errwrap"
@@ -44,13 +45,23 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	if krb5ConfPath == "" {
 		return nil, errors.New(`"krb5conf_path" is required`)
 	}
+	disableFAST := false
+	disableFASTNegotiation := m["disable_fast_negotiation"]
+	if disableFASTNegotiation != "" {
+		setting, err := strconv.ParseBool(disableFASTNegotiation)
+		if err != nil {
+			return nil, fmt.Errorf(`invalid value "%s" for disable_fast_negotiation, must be "true" or "false"`, disableFASTNegotiation)
+		}
+		disableFAST = setting
+	}
 
 	loginCfg := &LoginCfg{
-		Username:     username,
-		Service:      service,
-		Realm:        realm,
-		KeytabPath:   keytabPath,
-		Krb5ConfPath: krb5ConfPath,
+		Username:               username,
+		Service:                service,
+		Realm:                  realm,
+		KeytabPath:             keytabPath,
+		Krb5ConfPath:           krb5ConfPath,
+		DisableFASTNegotiation: disableFAST,
 	}
 
 	authHeaderVal, err := GetAuthHeaderVal(loginCfg)
@@ -115,6 +126,13 @@ Configuration:
 // GetAuthHeaderVal.
 type LoginCfg struct {
 	Username, Service, Realm, KeytabPath, Krb5ConfPath string
+
+	// FAST is a pre-authentication framework for Kerberos. It includes
+	// a mechanism for tunneling pre-authentication exchanges using armoured
+	// KDC messages. FAST provides increased resistance to passive password
+	// guessing attacks.
+	// Active Directory does not commonly support FAST negotiation.
+	DisableFASTNegotiation bool
 }
 
 // GetAuthHeaderVal is a convenience function that takes a given loginCfg
@@ -131,7 +149,13 @@ func GetAuthHeaderVal(loginCfg *LoginCfg) (string, error) {
 		return "", errwrap.Wrapf("couldn't parse krb5Conf: {{err}}", err)
 	}
 
-	cl := client.NewWithKeytab(loginCfg.Username, loginCfg.Realm, kt, krb5Conf, client.AssumePreAuthentication(true))
+	settings := []func(*client.Settings){
+		client.AssumePreAuthentication(true),
+	}
+	if loginCfg.DisableFASTNegotiation {
+		settings = append(settings, client.DisablePAFXFAST(true))
+	}
+	cl := client.NewWithKeytab(loginCfg.Username, loginCfg.Realm, kt, krb5Conf, settings...)
 	if err := cl.Login(); err != nil {
 		return "", errwrap.Wrapf("couldn't log in: {{err}}", err)
 	}

--- a/cmd/login-kerb/main.go
+++ b/cmd/login-kerb/main.go
@@ -19,12 +19,13 @@ import (
 )
 
 var (
-	username     string
-	service      string
-	realm        string
-	keytabPath   string
-	krb5ConfPath string
-	vaultAddr    string
+	username               string
+	service                string
+	realm                  string
+	keytabPath             string
+	krb5ConfPath           string
+	vaultAddr              string
+	disableFASTNegotiation bool
 )
 
 func init() {
@@ -34,6 +35,7 @@ func init() {
 	flag.StringVar(&keytabPath, "keytab_path", "", `ex: '/etc/krb5/krb5.keytab'`)
 	flag.StringVar(&krb5ConfPath, "krb5conf_path", "", `ex: '/etc/krb5/krb5.conf'`)
 	flag.StringVar(&vaultAddr, "vault_addr", "", `ex: 'http://localhost:8200'`)
+	flag.BoolVar(&disableFASTNegotiation, "disable_fast_negotiation", false, `ex: '-disable_fast_negotiation'`)
 }
 
 /*
@@ -45,7 +47,8 @@ login-kerb \
 	-realm=$REALM_NAME \
 	-keytab_path=$KRB5_CLIENT_KTNAME \
 	-krb5conf_path=$KRB5_CONFIG \
-	-vault_addr="http://$VAULT_CONTAINER_PREFIX.$DNS_NAME:8200"
+	-vault_addr="http://$VAULT_CONTAINER_PREFIX.$DNS_NAME:8200" \
+	-disable_fast_negotiation
 */
 
 func main() {
@@ -79,11 +82,12 @@ func main() {
 	}
 
 	loginCfg := &kerberos.LoginCfg{
-		Username:     username,
-		Service:      service,
-		Realm:        realm,
-		KeytabPath:   keytabPath,
-		Krb5ConfPath: krb5ConfPath,
+		Username:               username,
+		Service:                service,
+		Realm:                  realm,
+		KeytabPath:             keytabPath,
+		Krb5ConfPath:           krb5ConfPath,
+		DisableFASTNegotiation: disableFASTNegotiation,
 	}
 
 	authHeaderVal, err := kerberos.GetAuthHeaderVal(loginCfg)


### PR DESCRIPTION
Closes #40 

This PR allows FAST negotiation to be disabled by a client. This is necessary to support Active Directory.