### PR TITLE
Handle missing Authorization header on login path

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -91,8 +91,8 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 	}
 
 	authorizationString := ""
-	authorizationHeaders := req.Headers["Authorization"]
-	if len(authorizationHeaders) > 0 {
+	authorizationHeaders, hasAuthorizationHeader := req.Headers["Authorization"]
+	if hasAuthorizationHeader && len(authorizationHeaders) > 0 {
 		authorizationString = authorizationHeaders[0]
 	} else {
 		authorizationString = d.Get("authorization").(string)


### PR DESCRIPTION
Its a fairly typical usage pattern for clients to not pre-emptively
send kerberos credentials in a HTTP request, but react to a 401
response containing `WWW-Authenticate: Negotiate` and retry with
credentials.

Prior to this change, the plugin would panic when request.Headers
is nil due to an unchecked call to `len(nil)`. This change checks
whether the Authorization header was set, and tests that before
attempting to access it, thus avoiding the panic. The code will
continue until the absence of an authorizationString results in a
`401 authentication required` response, as expected.