### PR TITLE
Add support for Identity groups

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -264,6 +264,16 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 		auth.Policies = append(auth.Policies, policies...)
 	}
 
+	// Add the LDAP groups so the Identity system can use them
+	for _, groupName := range allGroups {
+		if groupName == "" {
+			continue
+		}
+		auth.GroupAliases = append(auth.GroupAliases, &logical.Alias{
+			Name: groupName,
+		})
+	}
+
 	return &logical.Response{
 		Auth: auth,
 	}, nil


### PR DESCRIPTION
Add support to the Kerberos plugin for using the Identity Group aliases. This PR takes the group names discovered in LDAP and returns them in the Auth response as GroupAliases. The code is patterned off the same bit of code in the LDAP auth plugin.