### PR TITLE
Patch a Bug that Prevents Kerberos Login via Vault Libraries or the Generic Vault "write" CLI

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -96,6 +96,12 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 		authorizationString = authorizationHeaders[0]
 	} else {
 		authorizationString = d.Get("authorization").(string)
+
+		// Add the Authorization header with the negotiated SPNEGO Token retrieved from the body of the API to the header
+		// of the request. Therefore, when the raw request is made later, "rebuiltReq" has it as the header.
+		req.Headers = map[string][]string{
+			"Authorization": {authorizationString},
+		}
 	}
 
 	kt, err := parseKeytab(kerbCfg.Keytab)


### PR DESCRIPTION
### Description
There is a bug in both [HashiCorp maintained version of “vault-plugin-auth-kerberos”](https://github.com/hashicorp/vault-plugin-auth-kerberos) and [Winton maintained version of “vault-plugin-auth-kerberos”](https://github.com/wintoncode/vault-plugin-auth-kerberos). The bug prevents the Vault client from making a successful call to [Kerberos Login API](https://www.vaultproject.io/api-docs/auth/kerberos#login-with-kerberos) using [Vault libraries](https://www.vaultproject.io/api/libraries.html) or [Vault generic “write” CLI](https://www.vaultproject.io/docs/commands/write). This is while the Vault client can successfully make a REST API call for Kerberos Login API. 

### Steps to Reproduce
1. [Install Vault](https://www.vaultproject.io/docs/install)
2. [Enable Kerberos auth method](https://www.vaultproject.io/docs/auth/kerberos#configuration)
3. [Configure Kerberos auth method](https://www.vaultproject.io/api-docs/auth/kerberos#configure-vault-kerberos) and [its LDAP configuration](https://www.vaultproject.io/api-docs/auth/kerberos#configure-kerberos-ldap)
4. Obtain a valid SPNEGO token i.e. [by the python script](https://github.com/hashicorp/vault-plugin-auth-kerberos#authentication)
5. Optional step to simply verify above steps: make a REST API call the Vault [Kerberos Login API](https://www.vaultproject.io/api-docs/auth/kerberos#login-with-kerberos) by specifying the obtained SPNEGO token at Step 4. You should be able to successfully login and obtain a Vault token. 
   * i.e. `curl --header "Authorization: Negotiate YIIFSw...sWw" --request POST http://127.0.0.1:8200/v1/auth/kerberos/login`
6. Now, call [the Kerberos Login](https://www.vaultproject.io/api-docs/auth/kerberos#login-with-kerberos) using either Step 7 or Step 8, the following, as oppose to a REST call. It would fail and throw a minimal error **with no details at all**. Before trying the following Step 7 and Step 8, If you tried the above Step 5, you would have to obtain another SPNEGO token as they are one-time use and would be consider replayed if used again.
7. Call By [Vault generic “write” CLI](https://www.vaultproject.io/docs/commands/write):
   * i.e. `vault write auth/kerberos/login authorization="Negotiate YIICng...gE="`
   * See the Error:
      * `Error writing data to auth/kerberos/login: Error making API request.`
`URL: PUT http://127.0.0.1:8200/v1/auth/kerberos/login`
`Code: 401. Errors:`
8. Call By [Vault libraries](https://www.vaultproject.io/api/libraries.html): 
   * i.e. [Vault Go Library](https://github.com/hashicorp/vault/tree/master/api):
      * `strSPNEGOToken := "YIICngYGKw..."`
`vaultPath := "http://127.0.0.1:8200/v1/auth/kerberos/login"`
`vaultData := map[string]interface{}{ "authorization": "Negotiate " + strSPNEGOToken }`
`vaultResponse, err:=vaultClient.Logical().Write(vaultPath, vaultData)`
   * See the Error:
      * `URL: PUT http://0.0.0.0:8200/v1/auth/kerberos/login`
`Code: 401. Errors:`
9. This is while you can successfully call [the Kerberos Login](https://www.vaultproject.io/api-docs/auth/kerberos#login-with-kerberos) using the its REST form, Step 5.
10. The expected behavior is no matter the form of the Vault client, whether a REST call, Vault library, or the Vault CLI, the call should be successful with a valid SPNEGO token and produce the same result.

### Solution
The PR addresses the bug.

### Details of the Bug
The issue happens because although [line 95 through 99 of the code](https://github.com/hashicorp/vault-plugin-auth-kerberos/blob/dbe25e7ff7578fb1b4bd7dff085119cdce80d5d7/path_login.go#L95-L99) checks whether the user provides the “Authorization: Negotiate ….” through the HTTP header or through the API’s body and fetches it accordingly, it does NOT set it part of the “req.Headers” once it is provided through the API’s body. This is while, “req.Headers” is referred in [the line 164](https://github.com/hashicorp/vault-plugin-auth-kerberos/blob/dbe25e7ff7578fb1b4bd7dff085119cdce80d5d7/path_login.go#L164) to re-compose the raw request to execute the SPNEGO authentication check. Therefore, it should include the “Authorization: Negotiate ….” no matter it was originally provided through HTTP header or the API body.

In another word, we need to manually add the Authorization header with the negotiated SPNEGO Token to the request’s header in the cases it is provided through API’s body. Therefore, when the raw request is made later, "[rebuiltReq](https://github.com/hashicorp/vault-plugin-auth-kerberos/blob/dbe25e7ff7578fb1b4bd7dff085119cdce80d5d7/path_login.go#L163)" has as the header to properly execute the SPNEGO authentication check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hashicorp/vault-plugin-auth-kerberos/52)
<!-- Reviewable:end -->
