### PR TITLE
fix: do not overwrite headers set by the client

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 
@@ -68,9 +67,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	if err != nil {
 		return nil, err
 	}
-	headers := http.Header{}
-	headers.Set(spnego.HTTPHeaderAuthRequest, authHeaderVal)
-	c.SetHeaders(headers)
+	c.AddHeader(spnego.HTTPHeaderAuthRequest, authHeaderVal)
 
 	path := fmt.Sprintf("auth/%s/login", mount)
 


### PR DESCRIPTION
This PR stops the authorization header from overwriting the other headers that were set by the client. These headers are necessary for features such as namespaces to work properly. 

eg. 
`vault login -method=kerberos -namespace=foo`

We ran into this issue while trying to use kerberos + namespaces. This was the fix that got the CLI to authenticate properly.