### PR TITLE
test: add bats acceptance test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ dev-dynamic: generate
 test: fmtcheck generate
 	CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC= go test -v -tags='$(BUILD_TAGS)' $(TEST) $(TESTARGS) -timeout=20m -parallel=4
 
+test-acceptance: dev-linux-only
+	 bats $(CURDIR)/test/acceptance/server-enterprise-basic-tests.bats
+
 testcompile: fmtcheck generate
 	@for pkg in $(TEST) ; do \
 		go test -v -c -tags='$(BUILD_TAGS)' $$pkg -parallel=4 ; \
@@ -68,4 +71,4 @@ dev-env: dev-linux-only
 integration: dev-linux-only
 	./scripts/integration_env.sh
 
-.PHONY: bin default generate test vet bootstrap fmt fmtcheck
+.PHONY: bin default generate test test-acceptance vet bootstrap fmt fmtcheck

--- a/README.md
+++ b/README.md
@@ -187,8 +187,9 @@ You can also specify a `TESTARGS` variable to filter tests like so:
 $ make test TESTARGS='--run=TestConfig'
 ```
 
-Acceptance tests requires a Vault Enterprise license to be provided
-and the following tools to be installed:
+Acceptance tests requires a Vault Enterprise license to be 
+[provided](https://www.vaultproject.io/docs/commands#vault_license) through 
+`VAULT_LICENSE` and the following tools to be installed:
 - [Docker](https://docs.docker.com/get-docker/)
 - [jq](https://stedolan.github.io/jq/)
 - [bats](https://bats-core.readthedocs.io/en/stable)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Put the plugin binary (`vault-plugin-auth-kerberos`) into a location of your cho
 will be specified as the [`plugin_directory`](https://www.vaultproject.io/docs/configuration/index.html#plugin_directory)
 in the Vault config used to start the server.
 
-```json
+```
 ...
 plugin_directory = "path/to/plugin/directory"
 ...
@@ -185,6 +185,17 @@ You can also specify a `TESTARGS` variable to filter tests like so:
 
 ```sh
 $ make test TESTARGS='--run=TestConfig'
+```
+
+Acceptance tests requires a Vault Enterprise license to be provided
+and the following tools to be installed:
+- [Docker](https://docs.docker.com/get-docker/)
+- [jq](https://stedolan.github.io/jq/)
+- [bats](https://bats-core.readthedocs.io/en/stable)
+
+
+```sh
+$ make test-acceptance VAULT_LICENSE=<vault-license>
 ```
 
 ## Contributors

--- a/scripts/dev_env.sh
+++ b/scripts/dev_env.sh
@@ -176,7 +176,7 @@ function stop_domain_joined_container() {
 
 function test_joined_container() {
   docker exec $DOMAIN_JOINED_CONTAINER \
-    pip install --quiet requests-kerberos
+    pip install --quiet requests-kerberos kerberos
   docker cp $WD/bin/login-kerb $DOMAIN_JOINED_CONTAINER:/usr/local/bin/login-kerb
 }
 

--- a/scripts/integration_env.sh
+++ b/scripts/integration_env.sh
@@ -267,7 +267,7 @@ function run_test_script() {
 
   # execute a login from python and record result
   docker exec $DOMAIN_JOINED_CONTAINER \
-    pip install --quiet requests-kerberos
+    pip install --quiet requests-kerberos kerberos
   docker exec $DOMAIN_JOINED_CONTAINER \
     python /tests/manual_test.py
   python_login_result=$?

--- a/test/acceptance/_helpers.bash
+++ b/test/acceptance/_helpers.bash
@@ -1,0 +1,211 @@
+VAULT_VER=$(curl -s "https://api.github.com/repos/hashicorp/vault/tags?page=1" | jq -r '.[0].name[1:]')_ent
+VAULT_IMAGE=vault-enterprise
+VAULT_PORT=8200
+VAULT_LICENSE=${VAULT_LICENSE?}
+
+SAMBA_VER=4.8.12
+
+DOMAIN_ADMIN_PASS=Pa55word!
+export DOMAIN_VAULT_ACCOUNT=vault_svc
+export DOMAIN_VAULT_PASS=vaultPa55word!
+export DOMAIN_USER_ACCOUNT=grace
+DOMAIN_USER_PASS=gracePa55word!
+
+SAMBA_CONF_FILE=/srv/etc/smb.conf
+DOMAIN_NAME=matrix
+export REALM_NAME=MATRIX.LAN
+export DOMAIN_DN=DC=MATRIX,DC=LAN
+TESTS_DIR=/tmp/vault_plugin_tests
+
+export VAULT_CONTAINER=vault-server
+export VAULT_TOKEN=root
+export DNS_NAME=matrix.lan
+export SAMBA_CONTAINER=samba-server
+export VAULT_ADDR=http://localhost:8200
+export DOMAIN_JOINED_CONTAINER=domain-joined-client
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  base64cmd="base64 -D"
+else
+  base64cmd="base64 -d"
+fi
+
+# plugin_dir returns the directory for the plugin
+plugin_dir() {
+    cd "${BATS_TEST_DIRNAME}/../../pkg/linux_amd64/" || return; pwd
+}
+
+function start_infrastructure() {
+  create_network
+  start_domain
+  start_vault
+}
+
+function stop_infrastructure() {
+  stop_domain_joined_container
+  stop_vault
+  stop_domain
+  delete_network
+}
+
+create_network() {
+  docker network create ${DNS_NAME}
+}
+
+delete_network() {
+  docker network rm ${DNS_NAME}
+}
+
+start_vault() {
+  docker run -d -ti --net=${DNS_NAME} \
+    --cap-add=IPC_LOCK \
+    -v "$(pwd)/pkg/linux_amd64:/plugins:Z" \
+    -e "VAULT_DEV_ROOT_TOKEN_ID=${VAULT_TOKEN}" \
+    -e "VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200" \
+    -e "VAULT_LICENSE=${VAULT_LICENSE}" \
+    -p 8200:8200 \
+    --name "${VAULT_CONTAINER}" \
+    "hashicorp/${VAULT_IMAGE}:${VAULT_VER}" server -dev -dev-plugin-dir="/plugins"
+}
+
+stop_vault() {
+  docker rm -f "${VAULT_CONTAINER}"
+}
+
+start_domain() {
+  docker run \
+  --net="${DNS_NAME}" \
+  -d -ti --privileged \
+  -p 135:135 -p 137:137 -p 138:138 -p 139:139 \
+  -p 389:389 -p 445:445 -p 464:464 -p 636:636 \
+  -p 3268:3268 -p 3269:3269 \
+  -e "SAMBA_DC_ADMIN_PASSWD=${DOMAIN_ADMIN_PASS}" \
+  -e "KERBEROS_PASSWORD=${DOMAIN_ADMIN_PASS}" \
+  -e SAMBA_DC_DOMAIN="${DOMAIN_NAME}" \
+  -e SAMBA_DC_REALM="${REALM_NAME}" \
+  --name "${SAMBA_CONTAINER}" \
+  "bodsch/docker-samba4:${SAMBA_VER}"
+}
+
+stop_domain() {
+  docker rm -f ${SAMBA_CONTAINER}
+}
+
+setup_users() {
+  add_user $DOMAIN_VAULT_ACCOUNT $DOMAIN_VAULT_PASS
+  create_keytab $DOMAIN_VAULT_ACCOUNT $DOMAIN_VAULT_PASS
+
+  add_user $DOMAIN_USER_ACCOUNT $DOMAIN_USER_PASS
+  create_keytab $DOMAIN_USER_ACCOUNT $DOMAIN_USER_PASS
+}
+
+add_user() {
+
+  username="${1}"
+  password="${2}"
+
+  if [[ $(check_user "${username}") -eq 0 ]]
+  then
+    echo "add user '${username}'"
+
+    docker exec "$SAMBA_CONTAINER" \
+      /usr/bin/samba-tool user create \
+      "${username}" \
+      "${password}"\
+      --configfile="${SAMBA_CONF_FILE}"
+  fi
+}
+
+check_user() {
+  username="${1}"
+
+  docker exec "$SAMBA_CONTAINER" \
+    /usr/bin/samba-tool user list \
+    --configfile=${SAMBA_CONF_FILE} \
+    | grep -c "${username}"
+}
+
+create_keytab() {
+  mkdir -p "${BATS_FILE_TMPDIR}"/integration
+
+  username="${1}"
+  password="${2}"
+
+  user_kvno=$(docker exec "$SAMBA_CONTAINER" \
+    bash -c "ldapsearch -H ldaps://localhost -D \"Administrator@${REALM_NAME}\"  -w \"${DOMAIN_ADMIN_PASS}\" -b \"CN=Users,${DOMAIN_DN}\" -LLL \"(&(objectClass=user)(sAMAccountName=${username}))\" msDS-KeyVersionNumber | sed -n 's/^[ \t]*msDS-KeyVersionNumber:[ \t]*\(.*\)/\1/p'")
+
+  docker exec "$SAMBA_CONTAINER" \
+    bash -c "printf \"%b\" \"addent -password -p \"${username}@${REALM_NAME}\" -k ${user_kvno} -e rc4-hmac\n${password}\nwrite_kt ${username}.keytab\" | ktutil"
+
+  docker exec "$SAMBA_CONTAINER" \
+    bash -c "printf \"%b\" \"read_kt ${username}.keytab\nlist\" | ktutil"
+
+  docker exec "$SAMBA_CONTAINER" \
+    base64 "${username}".keytab > "${BATS_FILE_TMPDIR}/integration/${username}.keytab.base64"
+}
+
+function add_vault_spn() {
+  docker exec $SAMBA_CONTAINER \
+    samba-tool spn add HTTP/"${VAULT_CONTAINER}" ${DOMAIN_VAULT_ACCOUNT} --configfile=${SAMBA_CONF_FILE}
+  docker exec $SAMBA_CONTAINER \
+    samba-tool spn add HTTP/"${VAULT_CONTAINER}":${VAULT_PORT} ${DOMAIN_VAULT_ACCOUNT} --configfile=${SAMBA_CONF_FILE}
+  docker exec $SAMBA_CONTAINER \
+    samba-tool spn add HTTP/"${VAULT_CONTAINER}".${DNS_NAME} ${DOMAIN_VAULT_ACCOUNT} --configfile=${SAMBA_CONF_FILE}
+  docker exec $SAMBA_CONTAINER \
+    samba-tool spn add HTTP/"${VAULT_CONTAINER}".${DNS_NAME}:${VAULT_PORT} ${DOMAIN_VAULT_ACCOUNT} --configfile=${SAMBA_CONF_FILE}
+}
+
+function write_kerb_config() {
+  echo "
+[libdefaults]
+  default_realm = ${REALM_NAME}
+  dns_lookup_realm = false
+  dns_lookup_kdc = true
+    ticket_lifetime = 24h
+    renew_lifetime = 7d
+    forwardable = true
+    rdns = false
+  preferred_preauth_types = 23
+[realms]
+  ${REALM_NAME} = {
+    kdc = ${SAMBA_CONTAINER}.${DNS_NAME}
+    admin_server = ${SAMBA_CONTAINER}.${DNS_NAME}
+    master_kdc = ${SAMBA_CONTAINER}.${DNS_NAME}
+    default_domain = ${SAMBA_CONTAINER}.${DNS_NAME}
+  }
+" > krb5.conf
+}
+
+function prepare_files() {
+  mkdir -p "${BATS_FILE_TMPDIR}"/integration
+  pushd "${BATS_FILE_TMPDIR}"/integration
+  write_kerb_config
+  eval "$base64cmd" grace.keytab.base64 > "${BATS_FILE_TMPDIR}/integration/grace.keytab"
+}
+
+function start_domain_joined_container() {
+  docker run \
+  --net=${DNS_NAME} \
+  -d -t \
+  -v "${BATS_FILE_TMPDIR}/integration:/tests:Z" \
+  -e KRB5_CONFIG=/tests/krb5.conf \
+  -e KRB5_CLIENT_KTNAME=/tests/grace.keytab \
+  --name "${DOMAIN_JOINED_CONTAINER}" \
+  python:3.7 cat
+}
+
+function stop_domain_joined_container() {
+  docker rm -f ${DOMAIN_JOINED_CONTAINER}
+}
+
+function test_joined_container() {
+  docker exec $DOMAIN_JOINED_CONTAINER \
+    pip install --quiet requests-kerberos kerberos
+}
+
+function prepare_outer_environment() {
+  prepare_files
+  start_domain_joined_container
+  test_joined_container
+}
+

--- a/test/acceptance/_helpers.bash
+++ b/test/acceptance/_helpers.bash
@@ -1,8 +1,12 @@
+# vault-related env vars
 VAULT_VER=$(curl -s "https://api.github.com/repos/hashicorp/vault/tags?page=1" | jq -r '.[0].name[1:]')_ent
 VAULT_IMAGE=vault-enterprise
 VAULT_PORT=8200
-VAULT_LICENSE=${VAULT_LICENSE?}
 
+# Error if the following env vars are not set
+[ "${VAULT_LICENSE:?}" ]
+
+# kerberos-related env vars
 SAMBA_VER=4.8.12
 
 DOMAIN_ADMIN_PASS=Pa55word!

--- a/test/acceptance/auth-check.py
+++ b/test/acceptance/auth-check.py
@@ -1,0 +1,15 @@
+import kerberos
+import requests
+import sys
+
+prefix = sys.argv[1]
+
+host = prefix + ".matrix.lan:8200"
+service = "HTTP@{}".format(host)
+rc, vc = kerberos.authGSSClientInit(service=service, mech_oid=kerberos.GSS_MECH_OID_SPNEGO)
+kerberos.authGSSClientStep(vc, "")
+kerberos_token = kerberos.authGSSClientResponse(vc)
+
+r = requests.post("http://{}/v1/admin/auth/kerberos/login".format(host),
+                  headers={'Authorization': 'Negotiate ' + kerberos_token})
+print('Vault token:', r.json()['auth']['client_token'])

--- a/test/acceptance/auth-check.py
+++ b/test/acceptance/auth-check.py
@@ -3,6 +3,7 @@ import requests
 import sys
 
 prefix = sys.argv[1]
+namespace = sys.argv[2]
 
 host = prefix + ".matrix.lan:8200"
 service = "HTTP@{}".format(host)
@@ -10,6 +11,6 @@ rc, vc = kerberos.authGSSClientInit(service=service, mech_oid=kerberos.GSS_MECH_
 kerberos.authGSSClientStep(vc, "")
 kerberos_token = kerberos.authGSSClientResponse(vc)
 
-r = requests.post("http://{}/v1/admin/auth/kerberos/login".format(host),
+r = requests.post("http://{}/v1/{}auth/kerberos/login".format(host, namespace),
                   headers={'Authorization': 'Negotiate ' + kerberos_token})
 print('Vault token:', r.json()['auth']['client_token'])

--- a/test/acceptance/server-enterprise-basic-tests.bats
+++ b/test/acceptance/server-enterprise-basic-tests.bats
@@ -13,7 +13,7 @@ if [[ -z "${VAULT_LICENSE}" ]]; then
 fi
 
 # setup sets up the infrastructure required for running these tests
-setup() {
+setup_file() {
   start_infrastructure
   sleep 15
 
@@ -22,7 +22,7 @@ setup() {
   prepare_outer_environment
 }
 
-teardown() {
+teardown_file() {
   stop_infrastructure
 }
 
@@ -70,14 +70,24 @@ login_kerberos() {
   docker exec -it "$DOMAIN_JOINED_CONTAINER" python /home/auth-check.py "$VAULT_CONTAINER" "${VAULT_NAMESPACE}"
 }
 
-@test "auth/kerberos: setup and authentication within a Vault namespace" {
-  create_namespace
-  register_plugin
-  enable_and_config_auth_kerberos
+@test "auth/kerberos: create namespace" {
+  run create_namespace
+  [ "${status?}" -eq 0 ]
+}
 
+@test "auth/kerberos: register plugin" {
+  run register_plugin
+  [ "${status?}" -eq 0 ]
+}
+
+@test "auth/kerberos: enable and configure auth method" {
+  run enable_and_config_auth_kerberos
+  [ "${status?}" -eq 0 ]
+}
+
+@test "auth/kerberos: setup and authentication within a Vault namespace" {
   run login_kerberos
   [ "${status?}" -eq 0 ]
 
   [[ "${output?}" =~ ^Vault[[:space:]]token\:[[:space:]].+$ ]]
 }
-

--- a/test/acceptance/server-enterprise-basic-tests.bats
+++ b/test/acceptance/server-enterprise-basic-tests.bats
@@ -2,11 +2,15 @@
 
 load _helpers
 
-export VAULT_ADDR='http://127.0.0.1:8200'
-export VAULT_LICENSE=${VAULT_LICENSE?}
+export VAULT_ADDR="http://127.0.0.1:8200"
 export VAULT_NAMESPACE=${VAULT_NAMESPACE:-"admin/"}
 
-VAULT_PLUGIN_SHA=$(openssl dgst -sha256 pkg/linux_amd64/vault-plugin-auth-kerberos|cut -d ' ' -f2)
+# todo: Whenever we add Vault OSS acceptance test,
+# we will have to make this conditional based on that
+if [[ -z "${VAULT_LICENSE}" ]]; then
+    echo "VAULT_LICENSE env var not set" >&2
+    exit 1
+fi
 
 # setup sets up the infrastructure required for running these tests
 setup() {

--- a/test/acceptance/server-enterprise-basic-tests.bats
+++ b/test/acceptance/server-enterprise-basic-tests.bats
@@ -15,7 +15,6 @@ fi
 # setup sets up the infrastructure required for running these tests
 setup_file() {
   start_infrastructure
-  sleep 15
 
   setup_users
   add_vault_spn

--- a/test/acceptance/server-enterprise-basic-tests.bats
+++ b/test/acceptance/server-enterprise-basic-tests.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+export VAULT_ADDR='http://127.0.0.1:8200'
+export VAULT_LICENSE=${VAULT_LICENSE?}
+
+VAULT_PLUGIN_SHA=$(openssl dgst -sha256 pkg/linux_amd64/vault-plugin-auth-kerberos|cut -d ' ' -f2)
+
+# setup sets up the infrastructure required for running these tests
+setup() {
+  start_infrastructure
+  sleep 15
+
+  setup_users
+  add_vault_spn
+  prepare_outer_environment
+}
+
+teardown() {
+  stop_infrastructure
+}
+
+create_namespace() {
+  vault namespace create admin
+}
+
+register_plugin() {
+  plugin_binary_path="$(plugin_dir)/vault-plugin-auth-kerberos"
+  VAULT_PLUGIN_SHA=$(openssl dgst -sha256 "$plugin_binary_path" | cut -d ' ' -f2)
+
+  vault write sys/plugins/catalog/auth/kerberos sha_256="${VAULT_PLUGIN_SHA}" command="vault-plugin-auth-kerberos"
+}
+
+enable_and_config_auth_kerberos() {
+  export VAULT_NAMESPACE=admin
+
+  vault auth enable \
+    -path=kerberos \
+    -passthrough-request-headers=Authorization \
+    -allowed-response-headers=www-authenticate \
+    vault-plugin-auth-kerberos
+
+  vault write auth/kerberos/config \
+    keytab=@vault_svc.keytab.base64 \
+    service_account="vault_svc"
+
+  vault write auth/kerberos/config/ldap \
+    binddn="${DOMAIN_VAULT_ACCOUNT}"@"${REALM_NAME}" \
+    bindpass="${DOMAIN_VAULT_PASS}" \
+    groupattr=sAMAccountName \
+    groupdn="${DOMAIN_DN}" \
+    groupfilter="(&(objectClass=group)(member:1.2.840.113556.1.4.1941:={{.UserDN}}))" \
+    insecure_tls=true \
+    starttls=true \
+    userdn="CN=Users,${DOMAIN_DN}" \
+    userattr=sAMAccountName \
+    upndomain="${REALM_NAME}" \
+    url=ldaps://"${SAMBA_CONTAINER:0:12}"."${DNS_NAME}"
+}
+
+login_kerberos() {
+  # docker exec -it "$DOMAIN_JOINED_CONTAINER" pip install kerberos
+  docker cp "${BATS_TEST_DIRNAME}"/auth-check.py "$DOMAIN_JOINED_CONTAINER":/home
+  docker exec -it "$DOMAIN_JOINED_CONTAINER" python /home/auth-check.py "$VAULT_CONTAINER"
+}
+
+@test "auth/kerberos: setup and authentication within a Vault namespace" {
+  create_namespace
+  register_plugin
+  enable_and_config_auth_kerberos
+  login_kerberos
+}
+


### PR DESCRIPTION
This PR ports and combines the acceptance test setup and execution from `scripts/dev_env.sh` and the README into BATs-based acceptance test. The current test is done specifically against Vault Enterprise (which requires a license), but this can be updated down the road to include OSS-only test setup and execution as well.

The test can be ran directly with `bats $(CURDIR)/test/acceptance/server-enterprise-basic-tests.bats` or ran through the make target `make test-acceptance` which also performs binary compilation. 