### PR TITLE
Minor acceptance test improvements

### DIFF
--- a/scripts/dev_env.sh
+++ b/scripts/dev_env.sh
@@ -165,6 +165,9 @@ function remove_files() {
 }
 
 function start_domain_joined_container() {
+  # Pull the container image first to ensure it will start up quickly,
+  # because when we run in the acceptance tests, we detach and move on immediately.
+  docker pull python:3.7
   DOMAIN_JOINED_CONTAINER=$(docker run --net=${DNS_NAME} -d -v "${TESTS_DIR}/integration:/tests:Z" -e KRB5_CONFIG=/tests/krb5.conf -e KRB5_CLIENT_KTNAME=/tests/grace.keytab -t python:3.7 cat)
 }
 

--- a/test/acceptance/_helpers.bash
+++ b/test/acceptance/_helpers.bash
@@ -95,12 +95,13 @@ start_domain() {
   sleep 1
 
   samba_readiness_check() {
-  docker exec "$SAMBA_CONTAINER" \
-    ldapsearch \
-    -H ldaps://localhost \
-    -D "Administrator@${REALM_NAME}" \
-    -w "${DOMAIN_ADMIN_PASS}" \
-    -b "${DOMAIN_DN}" '(objectClass=*)'
+    # Discard stdout (but not stderr), as it's a lot of noise.
+    docker exec "$SAMBA_CONTAINER" \
+      ldapsearch \
+        -H ldaps://localhost \
+        -D "Administrator@${REALM_NAME}" \
+        -w "${DOMAIN_ADMIN_PASS}" \
+        -b "${DOMAIN_DN}" '(objectClass=*)' > /dev/null
   }
   declare -fxr samba_readiness_check
 

--- a/test/acceptance/server-enterprise-basic-tests.bats
+++ b/test/acceptance/server-enterprise-basic-tests.bats
@@ -69,24 +69,31 @@ login_kerberos() {
   docker exec -it "$DOMAIN_JOINED_CONTAINER" python /home/auth-check.py "$VAULT_CONTAINER" "${VAULT_NAMESPACE}"
 }
 
+assert_success() {
+  if [ ! "${status?}" -eq 0 ]; then
+    echo "${output}"
+    exit $status
+  fi
+}
+
 @test "auth/kerberos: create namespace" {
   run create_namespace
-  [ "${status?}" -eq 0 ]
+  assert_success
 }
 
 @test "auth/kerberos: register plugin" {
   run register_plugin
-  [ "${status?}" -eq 0 ]
+  assert_success
 }
 
 @test "auth/kerberos: enable and configure auth method" {
   run enable_and_config_auth_kerberos
-  [ "${status?}" -eq 0 ]
+  assert_success
 }
 
 @test "auth/kerberos: setup and authentication within a Vault namespace" {
   run login_kerberos
-  [ "${status?}" -eq 0 ]
+  assert_success
 
   [[ "${output?}" =~ ^Vault[[:space:]]token\:[[:space:]].+$ ]]
 }


### PR DESCRIPTION
I had a few local environment issues that caused failures for me, so these changes mostly just make some minor improvements to test output on failure. Also pulls the python:3.7 docker image before running so that it reliably starts up in time before it's needed in the test.