### PR TITLE
Add remove_instance_name config to CLI and mount config

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -166,7 +166,7 @@ func GetAuthHeaderVal(loginCfg *LoginCfg) (string, error) {
 	}
 
 	if loginCfg.RemoveInstanceName {
-		removeInstanceName(kt)
+		removeInstanceNameFromKeytab(kt)
 	}
 
 	krb5Conf, err := config.Load(loginCfg.Krb5ConfPath)
@@ -205,12 +205,16 @@ func GetAuthHeaderVal(loginCfg *LoginCfg) (string, error) {
 	return authHeaderVal, nil
 }
 
-func removeInstanceName(kt *keytab.Keytab) {
+func removeInstanceNameFromKeytab(kt *keytab.Keytab) {
 	for index := range kt.Entries {
-		userSplit := strings.Split(kt.Entries[index].Principal.String(), "/")
-		if len(userSplit) > 1 {
-			kt.Entries[index].Principal.Components = []string{userSplit[0]}
+		user := splitUsername(kt.Entries[index].Principal.String())
+		if len(user) > 1 {
+			kt.Entries[index].Principal.Components = []string{user[0]}
 			kt.Entries[index].Principal.NumComponents = int16(len(kt.Entries[index].Principal.Components))
 		}
 	}
+}
+
+func splitUsername(username string) []string {
+	return strings.Split(username, "/")
 }

--- a/cli.go
+++ b/cli.go
@@ -40,10 +40,12 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	if keytabPath == "" {
 		return nil, errors.New(`"keytab_path" is required`)
 	}
+
 	krb5ConfPath := m["krb5conf_path"]
 	if krb5ConfPath == "" {
 		return nil, errors.New(`"krb5conf_path" is required`)
 	}
+
 	disableFAST := false
 	disableFASTNegotiation := m["disable_fast_negotiation"]
 	if disableFASTNegotiation != "" {
@@ -54,6 +56,16 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		disableFAST = setting
 	}
 
+	removeInstanceName := false
+	removeinstanceNameRaw := m["remove_instance_name"]
+	if removeinstanceNameRaw != "" {
+		setting, err := strconv.ParseBool(removeinstanceNameRaw)
+		if err != nil {
+			return nil, fmt.Errorf(`invalid value "%s" for remove_instance_name, must be "true" or "false"`, removeinstanceNameRaw)
+		}
+		removeInstanceName = setting
+	}
+
 	loginCfg := &LoginCfg{
 		Username:               username,
 		Service:                service,
@@ -61,6 +73,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		KeytabPath:             keytabPath,
 		Krb5ConfPath:           krb5ConfPath,
 		DisableFASTNegotiation: disableFAST,
+		RemoveInstanceName:     removeInstanceName,
 	}
 
 	authHeaderVal, err := GetAuthHeaderVal(loginCfg)
@@ -113,6 +126,12 @@ Configuration:
 
   realm=<string>
       The name of the Kerberos realm.
+
+  disable_fast_negotiation=<bool>
+      When set to true, disables the FAST pre-authentication framework.
+
+  remove_instance_name=<bool>
+      When set to true, strips instance names from the principal name in the keytab file.
 `
 
 	return strings.TrimSpace(help)
@@ -130,6 +149,11 @@ type LoginCfg struct {
 	// guessing attacks.
 	// Some common Kerberos implementations do not support FAST negotiation.
 	DisableFASTNegotiation bool
+
+	// Some keytab creators include FQDN in the username, which can cause
+	// issues during login when finding the user principal name in LDAP.
+	// When true, we will strip out any data after the username.
+	RemoveInstanceName bool
 }
 
 // GetAuthHeaderVal is a convenience function that takes a given loginCfg
@@ -139,6 +163,10 @@ func GetAuthHeaderVal(loginCfg *LoginCfg) (string, error) {
 	kt, err := keytab.Load(loginCfg.KeytabPath)
 	if err != nil {
 		return "", errwrap.Wrapf("couldn't load keytab: {{err}}", err)
+	}
+
+	if loginCfg.RemoveInstanceName {
+		removeInstanceName(kt)
 	}
 
 	krb5Conf, err := config.Load(loginCfg.Krb5ConfPath)
@@ -152,6 +180,7 @@ func GetAuthHeaderVal(loginCfg *LoginCfg) (string, error) {
 	if loginCfg.DisableFASTNegotiation {
 		settings = append(settings, client.DisablePAFXFAST(true))
 	}
+
 	cl := client.NewWithKeytab(loginCfg.Username, loginCfg.Realm, kt, krb5Conf, settings...)
 	if err := cl.Login(); err != nil {
 		return "", errwrap.Wrapf("couldn't log in: {{err}}", err)
@@ -172,4 +201,16 @@ func GetAuthHeaderVal(loginCfg *LoginCfg) (string, error) {
 	}
 	authHeaderVal := "Negotiate " + base64.StdEncoding.EncodeToString(marshalledToken)
 	return authHeaderVal, nil
+}
+
+func removeInstanceName(kt *keytab.Keytab) {
+	for index, entry := range kt.Entries {
+		if strings.Contains(entry.Principal.String(), "/") {
+			userSplit := strings.Split(kt.Entries[index].Principal.String(), "/")
+			if len(userSplit) > 1 {
+				kt.Entries[index].Principal.Components = []string{userSplit[0]}
+				kt.Entries[index].Principal.NumComponents = int16(len(kt.Entries[index].Principal.Components))
+			}
+		}
+	}
 }

--- a/cli.go
+++ b/cli.go
@@ -166,7 +166,7 @@ func GetAuthHeaderVal(loginCfg *LoginCfg) (string, error) {
 	}
 
 	if loginCfg.RemoveInstanceName {
-		removeInstanceNameFromKeytab(kt)
+		removeInstanceName(kt)
 	}
 
 	krb5Conf, err := config.Load(loginCfg.Krb5ConfPath)
@@ -205,21 +205,14 @@ func GetAuthHeaderVal(loginCfg *LoginCfg) (string, error) {
 	return authHeaderVal, nil
 }
 
-func removeInstanceNameFromKeytab(kt *keytab.Keytab) {
+func removeInstanceName(kt *keytab.Keytab) {
 	for index, entry := range kt.Entries {
 		if strings.Contains(entry.Principal.String(), "/") {
-			trimmed := trimUsername(entry.Principal.String())
-			kt.Entries[index].Principal.Components = []string{trimmed}
-			kt.Entries[index].Principal.NumComponents = int16(1)
-
+			userSplit := strings.Split(kt.Entries[index].Principal.String(), "/")
+			if len(userSplit) > 1 {
+				kt.Entries[index].Principal.Components = []string{userSplit[0]}
+				kt.Entries[index].Principal.NumComponents = int16(len(kt.Entries[index].Principal.Components))
+			}
 		}
 	}
-}
-
-func trimUsername(user string) string {
-	if strings.Contains(user, "/") {
-		split := strings.Split(user, "/")
-		user = split[0]
-	}
-	return user
 }

--- a/cli.go
+++ b/cli.go
@@ -206,13 +206,11 @@ func GetAuthHeaderVal(loginCfg *LoginCfg) (string, error) {
 }
 
 func removeInstanceName(kt *keytab.Keytab) {
-	for index, entry := range kt.Entries {
-		if strings.Contains(entry.Principal.String(), "/") {
-			userSplit := strings.Split(kt.Entries[index].Principal.String(), "/")
-			if len(userSplit) > 1 {
-				kt.Entries[index].Principal.Components = []string{userSplit[0]}
-				kt.Entries[index].Principal.NumComponents = int16(len(kt.Entries[index].Principal.Components))
-			}
+	for index := range kt.Entries {
+		userSplit := strings.Split(kt.Entries[index].Principal.String(), "/")
+		if len(userSplit) > 1 {
+			kt.Entries[index].Principal.Components = []string{userSplit[0]}
+			kt.Entries[index].Principal.NumComponents = int16(len(kt.Entries[index].Principal.Components))
 		}
 	}
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -27,7 +27,7 @@ func TestCLI_RemoveInstanceName(t *testing.T) {
 			t.Fatalf("got error adding entry, shouldn't have: %v", err)
 		}
 
-		removeInstanceName(&kt)
+		removeInstanceNameFromKeytab(&kt)
 		if kt.Entries[0].Principal.NumComponents != 1 {
 			t.Fatalf("expected num components to be 1, got %d", kt.Entries[0].Principal.NumComponents)
 		}

--- a/cli_test.go
+++ b/cli_test.go
@@ -27,7 +27,7 @@ func TestCLI_RemoveInstanceName(t *testing.T) {
 			t.Fatalf("got error adding entry, shouldn't have: %v", err)
 		}
 
-		removeInstanceNameFromKeytab(&kt)
+		removeInstanceName(&kt)
 		if kt.Entries[0].Principal.NumComponents != 1 {
 			t.Fatalf("expected num components to be 1, got %d", kt.Entries[0].Principal.NumComponents)
 		}

--- a/cli_test.go
+++ b/cli_test.go
@@ -27,8 +27,7 @@ func TestCLI_RemoveInstanceName(t *testing.T) {
 			t.Fatalf("got error adding entry, shouldn't have: %v", err)
 		}
 
-		removeInstanceName(&kt)
-
+		removeInstanceNameFromKeytab(&kt)
 		if kt.Entries[0].Principal.NumComponents != 1 {
 			t.Fatalf("expected num components to be 1, got %d", kt.Entries[0].Principal.NumComponents)
 		}

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,40 @@
+package kerberos
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jcmturner/gokrb5/v8/keytab"
+)
+
+func TestCLI_RemoveInstanceName(t *testing.T) {
+	type test struct {
+		principalName string
+		realm         string
+		want          string
+	}
+
+	tests := []test{
+		{principalName: "foobar/localhost", realm: "hashicorp.com", want: "foobar"},
+		{principalName: "foobar/localhost/test", realm: "hashicorp.com", want: "foobar"},
+		{principalName: "/localhost/test", realm: "hashicorp.com", want: ""},
+	}
+
+	for _, tc := range tests {
+		kt := keytab.Keytab{}
+		err := kt.AddEntry(tc.principalName, tc.realm, "password", time.Now(), 1, 17)
+		if err != nil {
+			t.Fatalf("got error adding entry, shouldn't have: %v", err)
+		}
+
+		removeInstanceName(&kt)
+
+		if kt.Entries[0].Principal.NumComponents != 1 {
+			t.Fatalf("expected num components to be 1, got %d", kt.Entries[0].Principal.NumComponents)
+		}
+
+		if kt.Entries[0].Principal.Components[0] != tc.want {
+			t.Fatalf("expected principal name to be %s, got %s", tc.want, kt.Entries[0].Principal.Components[0])
+		}
+	}
+}

--- a/path_config.go
+++ b/path_config.go
@@ -8,8 +8,9 @@ import (
 )
 
 type kerberosConfig struct {
-	Keytab         string `json:"keytab"`
-	ServiceAccount string `json:"service_account"`
+	Keytab             string `json:"keytab"`
+	ServiceAccount     string `json:"service_account"`
+	RemoveInstanceName bool   `json:"remove_instance_name"`
 }
 
 func (b *backend) pathConfig() *framework.Path {
@@ -26,6 +27,10 @@ func (b *backend) pathConfig() *framework.Path {
 			"service_account": {
 				Type:        framework.TypeString,
 				Description: `Service Account`,
+			},
+			"remove_instance_name": {
+				Type:        framework.TypeBool,
+				Description: `Remove instance/FQDN from keytab principal names.`,
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -54,7 +59,8 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, data
 		return &logical.Response{
 			Data: map[string]interface{}{
 				// keytab is intentionally not returned here because it's sensitive
-				"service_account": config.ServiceAccount,
+				"remove_instance_name": config.RemoveInstanceName,
+				"service_account":      config.ServiceAccount,
 			},
 		}, nil
 	}
@@ -71,14 +77,17 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 		return logical.ErrorResponse("data does not contain keytab"), logical.ErrInvalidRequest
 	}
 
+	removeInstanceName := data.Get("remove_instance_name").(bool)
+
 	// Check that the keytab is valid by parsing with krb5go
 	if _, err := parseKeytab(kt); err != nil {
 		return logical.ErrorResponse("invalid keytab: %v", err), logical.ErrInvalidRequest
 	}
 
 	config := &kerberosConfig{
-		Keytab:         kt,
-		ServiceAccount: serviceAccount,
+		Keytab:             kt,
+		ServiceAccount:     serviceAccount,
+		RemoveInstanceName: removeInstanceName,
 	}
 
 	entry, err := logical.StorageEntryJSON("config", config)

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -35,8 +35,9 @@ func TestConfig_ReadWrite(t *testing.T) {
 	b, storage := getTestBackend(t)
 
 	data := map[string]interface{}{
-		"keytab":          testValidKeytab,
-		"service_account": "testuser",
+		"keytab":               testValidKeytab,
+		"service_account":      "testuser",
+		"remove_instance_name": true,
 	}
 
 	req := &logical.Request{


### PR DESCRIPTION
It's not uncommon when generating keytab files for users to include hostnames in the service principal name, for example:

```
ktutil:  list
slot KVNO Principal
---- ---- ---------------------------------------------------------------------
   1    2 bob/hashi-J67927WY11@CORP.EXAMPLE.NET
```

Some users want the CLI to strip these instances if they're found while parsing the keytab during login to avoid authentication issues when searching LDAP for the user. To do this, I added a new CLI login parameter `remove_instance_name`, which will remove any instance names from the keytab file. It then sends the modified keytab file to Vault to be used for the login request.

Using this new parameter, a login might look like this:

```bash
$ vault login -method=kerberos \
      username=bob \
      service=HTTP/127.0.0.1 \
      realm=CORP.EXAMPLE.NET \
      keytab_path=./bob.keytab  \
      krb5conf_path=./configs/krb5.conf \
      disable_fast_negotiation=false \
      remove_instance_name=true
```

To enable server side trimming, I added a new config to the kerberos config, with the same name `remove_instance_name`:

```bash
vault write auth/kerberos/config \
    keytab=@vault.keytab.base64 \
    service_account="vault" \
    remove_instance_name=true
```
