### PR TITLE
Backport 1.11.x: Add remove_instance_name config to CLI and mount config (#68)

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -41,10 +41,12 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	if keytabPath == "" {
 		return nil, errors.New(`"keytab_path" is required`)
 	}
+
 	krb5ConfPath := m["krb5conf_path"]
 	if krb5ConfPath == "" {
 		return nil, errors.New(`"krb5conf_path" is required`)
 	}
+
 	disableFAST := false
 	disableFASTNegotiation := m["disable_fast_negotiation"]
 	if disableFASTNegotiation != "" {
@@ -55,6 +57,16 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		disableFAST = setting
 	}
 
+	removeInstanceName := false
+	removeinstanceNameRaw := m["remove_instance_name"]
+	if removeinstanceNameRaw != "" {
+		setting, err := strconv.ParseBool(removeinstanceNameRaw)
+		if err != nil {
+			return nil, fmt.Errorf(`invalid value "%s" for remove_instance_name, must be "true" or "false"`, removeinstanceNameRaw)
+		}
+		removeInstanceName = setting
+	}
+
 	loginCfg := &LoginCfg{
 		Username:               username,
 		Service:                service,
@@ -62,6 +74,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 		KeytabPath:             keytabPath,
 		Krb5ConfPath:           krb5ConfPath,
 		DisableFASTNegotiation: disableFAST,
+		RemoveInstanceName:     removeInstanceName,
 	}
 
 	authHeaderVal, err := GetAuthHeaderVal(loginCfg)
@@ -116,6 +129,12 @@ Configuration:
 
   realm=<string>
       The name of the Kerberos realm.
+
+  disable_fast_negotiation=<bool>
+      When set to true, disables the FAST pre-authentication framework.
+
+  remove_instance_name=<bool>
+      When set to true, strips instance names from the principal name in the keytab file.
 `
 
 	return strings.TrimSpace(help)
@@ -133,6 +152,11 @@ type LoginCfg struct {
 	// guessing attacks.
 	// Some common Kerberos implementations do not support FAST negotiation.
 	DisableFASTNegotiation bool
+
+	// Some keytab creators include FQDN in the username, which can cause
+	// issues during login when finding the user principal name in LDAP.
+	// When true, we will strip out any data after the username.
+	RemoveInstanceName bool
 }
 
 // GetAuthHeaderVal is a convenience function that takes a given loginCfg
@@ -142,6 +166,10 @@ func GetAuthHeaderVal(loginCfg *LoginCfg) (string, error) {
 	kt, err := keytab.Load(loginCfg.KeytabPath)
 	if err != nil {
 		return "", errwrap.Wrapf("couldn't load keytab: {{err}}", err)
+	}
+
+	if loginCfg.RemoveInstanceName {
+		removeInstanceNameFromKeytab(kt)
 	}
 
 	krb5Conf, err := config.Load(loginCfg.Krb5ConfPath)
@@ -155,6 +183,7 @@ func GetAuthHeaderVal(loginCfg *LoginCfg) (string, error) {
 	if loginCfg.DisableFASTNegotiation {
 		settings = append(settings, client.DisablePAFXFAST(true))
 	}
+
 	cl := client.NewWithKeytab(loginCfg.Username, loginCfg.Realm, kt, krb5Conf, settings...)
 	if err := cl.Login(); err != nil {
 		return "", errwrap.Wrapf("couldn't log in: {{err}}", err)
@@ -165,14 +194,30 @@ func GetAuthHeaderVal(loginCfg *LoginCfg) (string, error) {
 	if err := spnegoClient.AcquireCred(); err != nil {
 		return "", errwrap.Wrapf("couldn't acquire client credential: {{err}}", err)
 	}
+
 	spnegoToken, err := spnegoClient.InitSecContext()
 	if err != nil {
 		return "", errwrap.Wrapf("couldn't initialize context: {{err}}", err)
 	}
+
 	marshalledToken, err := spnegoToken.Marshal()
 	if err != nil {
 		return "", errwrap.Wrapf("couldn't marshal SPNEGO: {{err}}", err)
 	}
 	authHeaderVal := "Negotiate " + base64.StdEncoding.EncodeToString(marshalledToken)
 	return authHeaderVal, nil
+}
+
+func removeInstanceNameFromKeytab(kt *keytab.Keytab) {
+	for index := range kt.Entries {
+		user := splitUsername(kt.Entries[index].Principal.String())
+		if len(user) > 1 {
+			kt.Entries[index].Principal.Components = []string{user[0]}
+			kt.Entries[index].Principal.NumComponents = int16(len(kt.Entries[index].Principal.Components))
+		}
+	}
+}
+
+func splitUsername(username string) []string {
+	return strings.Split(username, "/")
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,39 @@
+package kerberos
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jcmturner/gokrb5/v8/keytab"
+)
+
+func TestCLI_RemoveInstanceName(t *testing.T) {
+	type test struct {
+		principalName string
+		realm         string
+		want          string
+	}
+
+	tests := []test{
+		{principalName: "foobar/localhost", realm: "hashicorp.com", want: "foobar"},
+		{principalName: "foobar/localhost/test", realm: "hashicorp.com", want: "foobar"},
+		{principalName: "/localhost/test", realm: "hashicorp.com", want: ""},
+	}
+
+	for _, tc := range tests {
+		kt := keytab.Keytab{}
+		err := kt.AddEntry(tc.principalName, tc.realm, "password", time.Now(), 1, 17)
+		if err != nil {
+			t.Fatalf("got error adding entry, shouldn't have: %v", err)
+		}
+
+		removeInstanceNameFromKeytab(&kt)
+		if kt.Entries[0].Principal.NumComponents != 1 {
+			t.Fatalf("expected num components to be 1, got %d", kt.Entries[0].Principal.NumComponents)
+		}
+
+		if kt.Entries[0].Principal.Components[0] != tc.want {
+			t.Fatalf("expected principal name to be %s, got %s", tc.want, kt.Entries[0].Principal.Components[0])
+		}
+	}
+}

--- a/path_config.go
+++ b/path_config.go
@@ -8,8 +8,9 @@ import (
 )
 
 type kerberosConfig struct {
-	Keytab         string `json:"keytab"`
-	ServiceAccount string `json:"service_account"`
+	Keytab             string `json:"keytab"`
+	ServiceAccount     string `json:"service_account"`
+	RemoveInstanceName bool   `json:"remove_instance_name"`
 }
 
 func (b *backend) pathConfig() *framework.Path {
@@ -26,6 +27,10 @@ func (b *backend) pathConfig() *framework.Path {
 			"service_account": {
 				Type:        framework.TypeString,
 				Description: `Service Account`,
+			},
+			"remove_instance_name": {
+				Type:        framework.TypeBool,
+				Description: `Remove instance/FQDN from keytab principal names.`,
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -54,7 +59,8 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, data
 		return &logical.Response{
 			Data: map[string]interface{}{
 				// keytab is intentionally not returned here because it's sensitive
-				"service_account": config.ServiceAccount,
+				"remove_instance_name": config.RemoveInstanceName,
+				"service_account":      config.ServiceAccount,
 			},
 		}, nil
 	}
@@ -71,14 +77,17 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 		return logical.ErrorResponse("data does not contain keytab"), logical.ErrInvalidRequest
 	}
 
+	removeInstanceName := data.Get("remove_instance_name").(bool)
+
 	// Check that the keytab is valid by parsing with krb5go
 	if _, err := parseKeytab(kt); err != nil {
 		return logical.ErrorResponse("invalid keytab: %v", err), logical.ErrInvalidRequest
 	}
 
 	config := &kerberosConfig{
-		Keytab:         kt,
-		ServiceAccount: serviceAccount,
+		Keytab:             kt,
+		ServiceAccount:     serviceAccount,
+		RemoveInstanceName: removeInstanceName,
 	}
 
 	entry, err := logical.StorageEntryJSON("config", config)

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -35,8 +35,9 @@ func TestConfig_ReadWrite(t *testing.T) {
 	b, storage := getTestBackend(t)
 
 	data := map[string]interface{}{
-		"keytab":          testValidKeytab,
-		"service_account": "testuser",
+		"keytab":               testValidKeytab,
+		"service_account":      "testuser",
+		"remove_instance_name": true,
 	}
 
 	req := &logical.Request{

--- a/path_login.go
+++ b/path_login.go
@@ -103,6 +103,10 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 		return nil, errwrap.Wrapf("could not parse keytab: {{err}}", err)
 	}
 
+	if kerbCfg.RemoveInstanceName {
+		removeInstanceNameFromKeytab(kt)
+	}
+
 	s := strings.SplitN(authorizationString, " ", 2)
 	if len(s) != 2 || s[0] != "Negotiate" {
 		return b.pathLoginGet(ctx, req, d)
@@ -130,6 +134,13 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 		}
 		b.Logger().Debug(fmt.Sprintf("identity: %+v", identity))
 		username = identity.UserName()
+
+		if kerbCfg.RemoveInstanceName {
+			user := splitUsername(identity.UserName())
+			if len(user) > 1 {
+				username = user[0]
+			}
+		}
 
 		// Verify that the realm on the LDAP config (if set) is the same as the identity's
 		// realm. The UPNDomain denotes the realm on the LDAP config, and the identity
@@ -203,7 +214,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 		return nil, fmt.Errorf("LDAP bind failed: %v", err)
 	}
 
-	userBindDN, err := ldapClient.GetUserBindDN(ldapCfg.ConfigEntry, ldapConnection, identity.UserName())
+	userBindDN, err := ldapClient.GetUserBindDN(ldapCfg.ConfigEntry, ldapConnection, username)
 	if err != nil {
 		return nil, errwrap.Wrapf("unable to get user binddn: {{err}}", err)
 	}
@@ -214,7 +225,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 		return nil, errwrap.Wrapf("unable to get user dn: {{err}}", err)
 	}
 
-	ldapGroups, err := ldapClient.GetLdapGroups(ldapCfg.ConfigEntry, ldapConnection, userDN, identity.UserName())
+	ldapGroups, err := ldapClient.GetLdapGroups(ldapCfg.ConfigEntry, ldapConnection, userDN, username)
 	if err != nil {
 		return nil, errwrap.Wrapf("unable to get ldap groups: {{err}}", err)
 	}


### PR DESCRIPTION
* Add remove_instance_name config to CLI

* Add server side processing

* Remove trimming from username

* Remove redundant check for trimming

* Also split username serverside