### PR TITLE
Backport of: fix: do not overwrite headers set by the client

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 
@@ -81,9 +80,7 @@ func (h *CLIHandler) Auth(c *api.Client, m map[string]string) (*api.Secret, erro
 	if err != nil {
 		return nil, err
 	}
-	headers := http.Header{}
-	headers.Set(spnego.HTTPHeaderAuthRequest, authHeaderVal)
-	c.SetHeaders(headers)
+	c.AddHeader(spnego.HTTPHeaderAuthRequest, authHeaderVal)
 
 	path := fmt.Sprintf("auth/%s/login", mount)
 


### PR DESCRIPTION
This is a backport of the bugfix https://github.com/hashicorp/vault-plugin-auth-kerberos/pull/61 for Vault 1.11.x