### PR TITLE
Add support for CCache-based user logins

### DIFF
--- a/cmd/login-kerb/main.go
+++ b/cmd/login-kerb/main.go
@@ -57,17 +57,17 @@ func main() {
 		fmt.Println(`"username" is required`)
 		os.Exit(1)
 	}
-	if service == "" {
-		fmt.Println(`"service" is required`)
-		os.Exit(1)
-	}
-	if realm == "" {
-		fmt.Println(`"realm" is required`)
-		os.Exit(1)
-	}
 	if keytabPath == "" {
-		fmt.Println(`"keytab_path" is required`)
-		os.Exit(1)
+		fmt.Println(`"keytab_path" not specified, defaulting to ticket cache`)
+	} else {
+		if service == "" {
+			fmt.Println(`"service" is required`)
+			os.Exit(1)
+		}
+		if realm == "" {
+			fmt.Println(`"realm" is required`)
+			os.Exit(1)
+		}
 	}
 	if krb5ConfPath == "" {
 		fmt.Println(`"krb5conf_path" is required`)


### PR DESCRIPTION
Hey there!

It appears that currently we assume that the user always holds a keytab - however, when a normal user runs `kinit`, they will usually just end up with a ticket in their credential cache.

This PR makes the keytabPath, username and realm parameters
optional. If they are not set, it instead tries to look for the current
user's credential cache, using that to log in.
Due to limitations in the kerberos library used, currently, only 'FILE'
type credential caches are supported.