### PR TITLE
Update CHANGELOG, add bats instructions comment, up samba setup wait-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,23 @@
 
 * Add new features here
 
-## 0.7.2 (Aug 8th, 2022)
+## v0.8.0
+
+* Plugin release milestone
+
+## v0.7.3
+
+### IMPROVEMENTS
+
+* Add config parameter to include group aliases found in LDAP [[GH-73](https://github.com/hashicorp/vault-plugin-auth-kerberos/pull/73)]
+
+## v0.7.2
 
 ### BUG FIXES
 
 * Maintain headers set by the client [[GH-61](https://github.com/hashicorp/vault-plugin-auth-kerberos/pull/61)]
 
-## 0.7.1 (Aug 4th, 2022)
+## v0.7.1
 
 ### IMPROVEMENTS
 

--- a/test/acceptance/_helpers.bash
+++ b/test/acceptance/_helpers.bash
@@ -105,7 +105,7 @@ start_domain() {
   }
   declare -fxr samba_readiness_check
 
-  timeout 20s bash -c 'until samba_readiness_check; do sleep 2; done'
+  timeout 60s bash -c 'until samba_readiness_check; do sleep 2; done'
 
   echo "Samba container ready!"
 }

--- a/test/acceptance/server-enterprise-basic-tests.bats
+++ b/test/acceptance/server-enterprise-basic-tests.bats
@@ -1,5 +1,8 @@
 #!/usr/bin/env bats
 
+# First run 'make bin' to generate a linux binary in the pkg directory,
+# then run bats from the root directory of the project - not from here!
+
 load _helpers
 
 export VAULT_ADDR="http://127.0.0.1:8200"


### PR DESCRIPTION
Perhaps because of the samba container being amd64, the bats test on my M1 Mac takes much longer than the 20 seconds that the script currently allocates, so upped it to 60s.

Also added a comment at the top of the Bats test script to indicate requirements. 

CHANGELOG update.