### PR TITLE
Reduce verbosity of failed group lookups

### DIFF
--- a/path_login.go
+++ b/path_login.go
@@ -252,11 +252,11 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 	for _, groupName := range allGroups {
 		group, err := b.Group(ctx, req.Storage, groupName)
 		if err != nil {
-			b.Logger().Warn(fmt.Sprintf("unable to retrieve %s: %s", groupName, err.Error()))
+			b.Logger().Debug(fmt.Sprintf("unable to retrieve %s: %s", groupName, err.Error()))
 			continue
 		}
 		if group == nil {
-			b.Logger().Warn(fmt.Sprintf("unable to find %s, does not currently exist", groupName))
+			b.Logger().Debug(fmt.Sprintf("unable to find %s, does not currently exist", groupName))
 			continue
 		}
 		policies = append(policies, group.Policies...)


### PR DESCRIPTION
Reduce the verbosity from Warn to Debug for failed group lookups when retrieving policies. There may be legitimate reasons why a group visible in the directory is not visible on the local system and this causes excessive log spam.