### PR TITLE
Adding the `disable_pac` option according to `gokrb5` options

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -15,6 +15,7 @@ type kerberosConfig struct {
 	ServiceAccount     string `json:"service_account"`
 	AddGroupAliases    bool   `json:"add_group_aliases"`
 	RemoveInstanceName bool   `json:"remove_instance_name"`
+	DisablePAC         bool   `json:"disable_pac"`
 }
 
 func (b *backend) pathConfig() *framework.Path {
@@ -43,6 +44,10 @@ func (b *backend) pathConfig() *framework.Path {
 			"remove_instance_name": {
 				Type:        framework.TypeBool,
 				Description: `Remove instance/FQDN from keytab principal names.`,
+			},
+			"disable_pac": {
+				Type:        framework.TypeBool,
+				Description: `Disables the processing ot PAC which leads to error when using non-Microsoft Kerberos.`,
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -77,6 +82,7 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, data
 				"service_account":      config.ServiceAccount,
 				"add_group_aliases":    config.AddGroupAliases,
 				"remove_instance_name": config.RemoveInstanceName,
+				"disable_pac":          config.DisablePAC,
 			},
 		}, nil
 	}
@@ -95,6 +101,7 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 
 	addGroupAliases := data.Get("add_group_aliases").(bool)
 	removeInstanceName := data.Get("remove_instance_name").(bool)
+	disablePAC := data.Get("disable_pac").(bool)
 
 	// Check that the keytab is valid by parsing with krb5go
 	if _, err := parseKeytab(kt); err != nil {
@@ -106,6 +113,7 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 		ServiceAccount:     serviceAccount,
 		AddGroupAliases:    addGroupAliases,
 		RemoveInstanceName: removeInstanceName,
+		DisablePAC:         disablePAC,
 	}
 
 	entry, err := logical.StorageEntryJSON("config", config)

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -42,6 +42,7 @@ func TestConfig_ReadWrite(t *testing.T) {
 		"service_account":      "testuser",
 		"remove_instance_name": true,
 		"add_group_aliases":    true,
+		"disable_pac":          false,
 	}
 
 	req := &logical.Request{

--- a/path_login.go
+++ b/path_login.go
@@ -176,7 +176,7 @@ func (b *backend) pathLoginUpdate(ctx context.Context, req *logical.Request, d *
 	})
 
 	// Now let's use our inner handler to compose the overall function.
-	authHTTPHandler := spnego.SPNEGOKRB5Authenticate(inner, kt, service.Logger(l), service.KeytabPrincipal(kerbCfg.ServiceAccount))
+	authHTTPHandler := spnego.SPNEGOKRB5Authenticate(inner, kt, service.Logger(l), service.KeytabPrincipal(kerbCfg.ServiceAccount), service.DecodePAC(!kerbCfg.DisablePAC))
 
 	// Because the outer application strips off the raw request, we need to
 	// re-compose it to use this authentication handler. Only the request

--- a/scripts/dev_env.sh
+++ b/scripts/dev_env.sh
@@ -60,7 +60,7 @@ function delete_network() {
 }
 
 function start_vault() {
-  VAULT_CONTAINER=$(docker run --net=${DNS_NAME} -d -ti --cap-add=IPC_LOCK -v $(pwd)/pkg/linux_amd64:/plugins:Z -e "VAULT_DEV_ROOT_TOKEN_ID=${VAULT_TOKEN}" -e "VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:${VAULT_PORT}" -p ${VAULT_PORT}:${VAULT_PORT} hashicorp/vault:${VAULT_IMAGE_TAG} server -dev -dev-plugin-dir=/plugins)
+  VAULT_CONTAINER=$(docker run --net=${DNS_NAME} -d -ti --cap-add=IPC_LOCK -v $(pwd)/pkg/linux_amd64:/plugins:Z -e "VAULT_DEV_ROOT_TOKEN_ID=${VAULT_TOKEN}" -e "VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:${VAULT_PORT}" -p ${VAULT_PORT}:${VAULT_PORT} docker.io/hashicorp/vault:${VAULT_IMAGE_TAG} server -dev -dev-plugin-dir=/plugins)
   export VAULT_ADDR=http://127.0.0.1:${VAULT_PORT}
 }
 
@@ -69,7 +69,7 @@ function stop_vault() {
 }
 
 function start_domain() {
-  SAMBA_CONTAINER=$(docker run --net=${DNS_NAME} -d -ti --privileged -p 135:135 -p 137:137 -p 138:138 -p 139:139 -p 389:389 -p 445:445 -p 464:464 -p 636:636 -p 3268:3268 -p 3269:3269 -e "SAMBA_DC_ADMIN_PASSWD=${DOMAIN_ADMIN_PASS}" -e "KERBEROS_PASSWORD=${DOMAIN_ADMIN_PASS}" -e SAMBA_DC_DOMAIN=${DOMAIN_NAME} -e SAMBA_DC_REALM=${REALM_NAME} "bodsch/docker-samba4:${SAMBA_VER}")
+  SAMBA_CONTAINER=$(docker run --net=${DNS_NAME} -d -ti --privileged -p 135:135 -p 137:137 -p 138:138 -p 139:139 -p 389:389 -p 445:445 -p 464:464 -p 636:636 -p 3268:3268 -p 3269:3269 -e "SAMBA_DC_ADMIN_PASSWD=${DOMAIN_ADMIN_PASS}" -e "KERBEROS_PASSWORD=${DOMAIN_ADMIN_PASS}" -e SAMBA_DC_DOMAIN=${DOMAIN_NAME} -e SAMBA_DC_REALM=${REALM_NAME} "docker.io/bodsch/docker-samba4:${SAMBA_VER}")
   # shouldn't need to publish all these ports as they are only used within the docker network, but figured it may be useful for debugging
 }
 
@@ -178,7 +178,7 @@ function start_domain_joined_container() {
   # Pull the container image first to ensure it will start up quickly,
   # because when we run in the acceptance tests, we detach and move on immediately.
   docker pull python:3.7
-  DOMAIN_JOINED_CONTAINER=$(docker run --net=${DNS_NAME} -d -v "${TESTS_DIR}/integration:/tests:Z" -e KRB5_CONFIG=/tests/krb5.conf -e KRB5_CLIENT_KTNAME=/tests/grace.keytab -t python:3.7 cat)
+  DOMAIN_JOINED_CONTAINER=$(docker run --net=${DNS_NAME} -d -v "${TESTS_DIR}/integration:/tests:Z" -e KRB5_CONFIG=/tests/krb5.conf -e KRB5_CLIENT_KTNAME=/tests/grace.keytab -t docker.io/python:3.7 cat)
 }
 
 function stop_domain_joined_container() {

--- a/scripts/integration_env.sh
+++ b/scripts/integration_env.sh
@@ -63,7 +63,7 @@ function start_vault() {
     -e "VAULT_DEV_ROOT_TOKEN_ID=${VAULT_TOKEN}" \
     -e "VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:${VAULT_PORT}" \
     -p ${VAULT_PORT}:${VAULT_PORT} \
-    hashicorp/vault:${VAULT_IMAGE_TAG} server -dev -dev-plugin-dir=/tmp/repo-root/pkg/linux_amd64)
+    docker.io/hashicorp/vault:${VAULT_IMAGE_TAG} server -dev -dev-plugin-dir=/tmp/repo-root/pkg/linux_amd64)
   export VAULT_ADDR=http://127.0.0.1:${VAULT_PORT}
 }
 
@@ -77,7 +77,7 @@ function start_domain() {
     -e "SAMBA_DC_ADMIN_PASSWD=${DOMAIN_ADMIN_PASS}" \
     -e "KERBEROS_PASSWORD=${DOMAIN_ADMIN_PASS}" \
     -e SAMBA_DC_DOMAIN=${DOMAIN_NAME} \
-    -e SAMBA_DC_REALM=${REALM_NAME} "bodsch/docker-samba4:${SAMBA_VER}")
+    -e SAMBA_DC_REALM=${REALM_NAME} "docker.io/bodsch/docker-samba4:${SAMBA_VER}")
   # shouldn't need to publish all these ports as they are only used within the docker network, but figured it may be useful for debugging
 }
 
@@ -231,7 +231,7 @@ function start_domain_joined_container() {
     -v "${TESTS_DIR}/integration:/tests:Z" \
     -e KRB5_CONFIG=/tests/krb5.conf \
     -e KRB5_CLIENT_KTNAME=/tests/grace.keytab \
-    -t python:3.7 cat)
+    -t docker.io/library/python:3.7 cat)
 }
 
 function stop_domain_joined_container() {


### PR DESCRIPTION
Hello !

This is a change adding a `disable_pac` option to this plugin, enabling to disable the handling and parsing of the Kerberos PAC within `gokrb5`.

This solves and issue when using non-microsoft Kerberos implementations leads to this error:
> [INFO]  auth.kerberos.auth_kerberos_3570a43d: 10.80.50.115:8080 - SPNEGO validation error: defective token detected: PAC Info Buffers does not contain a KerbValidationInfo

When trying to login using spnego.

As `gokrb5` only implements the PAC parsing according to Microsoft's format which is not used by other implementations such as FreeIPA or MIT Kerberos.

This option is purely optional and not enabled by default.

Ref: 

https://github.com/jcmturner/gokrb5/blob/master/service/APExchange.go#L39
https://github.com/jcmturner/gokrb5/blob/855dbc707a37a21467aef6c0245fcf3328dc39ed/messages/Ticket.go#L219