### PR TITLE
[CHANGELOG] Prepare for v0.17.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.17.1
+### March 20, 2026
+
+* golang vuln fix (#147)
+* Automated dependency upgrades (#146)
+* Update changelog for v0.17.0 release (#145)
+
 ## v0.17.0
 ### March 18, 2026
 


### PR DESCRIPTION
Changelog update for version [v0.17.1](https://github.com/hashicorp/vault-plugin-auth-kerberos/releases/tag/v0.17.1).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/23331252651

