### PR TITLE
[CHANGELOG] Prepare for v0.18.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.18.0
+### September 11, 2026
+
+* chore: automated Go/dependency update via vault-plugin-release (#159)
+* Bump golang.org/x/crypto from 0.49.0 to 0.52.0 (#142)
+* Update changelog for v0.17.1 release (#148)
+
 ## v0.17.1
 ### March 20, 2026
 


### PR DESCRIPTION
Changelog update for version [v0.18.0](https://github.com/hashicorp/vault-plugin-auth-kerberos/releases/tag/v0.18.0).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/34570625153

